### PR TITLE
Fixes #17642 by adding info contact url to the generated OpenAPIDefin…

### DIFF
--- a/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/RestApplication.mustache
+++ b/modules/openapi-generator/src/main/resources/JavaJaxRS/spec/RestApplication.mustache
@@ -9,7 +9,7 @@ import {{javaxPackage}}.ws.rs.core.Application;
         {{#appName}},title = "{{{.}}}"{{/appName}}
         {{#appDescription}},description = "{{{.}}}"{{/appDescription}}
         {{#license}},license = @org.eclipse.microprofile.openapi.annotations.info.License(name = "{{{licenseInfo}}}", url = "{{{licenseUrl}}}"){{/license}}
-        {{#contact}},contact = @org.eclipse.microprofile.openapi.annotations.info.Contact(name = "{{{infoName}}}", email = "{{{infoEmail}}}"){{/contact}}
+        {{#contact}},contact = @org.eclipse.microprofile.openapi.annotations.info.Contact(name = "{{{infoName}}}", email = "{{{infoEmail}}}", url = "{{{infoUrl}}}"){{/contact}}
 )){{/info}}{{/openAPI}}{{/useMicroProfileOpenAPIAnnotations}}
 @ApplicationPath(RestResourceRoot.APPLICATION_PATH)
 public class RestApplication extends Application {


### PR DESCRIPTION
When an OpenAPI specification contains a block info > contact > url, this url is not added to the generated OpenAPIDefinition, which is added to the RestApplication class. This pull request fixes that.

### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@chameleon82 @bbdouglas @sreeshas  @jfiala  @lukoyanov  @cbornet  @jeff9finger  @karismann  @Zomzog  @lwlee2608  @martin-mfg 